### PR TITLE
CacheEvict on Service.save(), show changes on save

### DIFF
--- a/src/main/java/com/enterprise4045/groceryplanner/service/LoggedItemServiceStub.java
+++ b/src/main/java/com/enterprise4045/groceryplanner/service/LoggedItemServiceStub.java
@@ -46,6 +46,7 @@ public class LoggedItemServiceStub implements ILoggedItemService {
     }
 
     @Override
+    @CacheEvict(value="LoggedItems")
     public LoggedItem save(LoggedItem loggedItem) throws Exception {
         return loggedItemDAO.save(loggedItem);
     }


### PR DESCRIPTION
Adding CacheEvict on the LoggedItemService.save() method so that the LoggedItems list will be updated once a new item is added.